### PR TITLE
Fixed issue with format being matched incorrectly

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -267,7 +267,7 @@ format.addMatch('BluRay', 'BD25', 40).setQuality(100);
 format.addMatch('BluRay', 'BD50', 40).setQuality(100);
 format.addMatch('BluRay', 'B[DR]', 40).setQuality(100);
 format.addMatch('BluRay', 'B[DR]-Rip', 50).setQuality(100);
-format.addMatch('BluRay', 'Blu-ray', 50).setQuality(100);
+format.addMatch('BluRay', /blu-?ray/i, 50).setQuality(100);
 format.addMatch('BluRay', 'Blu-ray-Rip', 70).setQuality(100);
 
 // Resolutions

--- a/test/episodes-epinfer.yaml
+++ b/test/episodes-epinfer.yaml
@@ -471,3 +471,16 @@ series/Psych/Psych S02 Season 2 Complete English DVD/Psych.S02E02.65.Million.Yea
   series: Psych
   subtype: episode
   title: 65 Million Years Off
+
+the.librarians.s01e01.720p.bluray.x264-bia.nzb:
+  series: The Librarians
+  container: NewzBin Usenet Index File
+  subtype: episode
+  extension: nzb
+  filetype: index
+  episode: 1
+  season: 1
+  format: BluRay
+  screen_size: 720p
+  video_codec: h264
+  release_group: bia


### PR DESCRIPTION
I ran into an issue with the filename `the.librarians.s01e01.720p.bluray.x264-bia.nzb`, which yielded an undefined `series` property.

I tracked it down to `bluray` not being recognized by the parser, combined with the `br` in `librarians` being matched by `format.addMatch('BluRay', 'B[DR]', 40)`, which invalidates the series name parser.

