### PR TITLE
Fixed issue with "8bit" in series name being incorrectly parsed as video_profile

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -310,7 +310,7 @@ profile.addMatch('HP', /\bHiP\b/, 15).setQuality(10).require('video_codec');
 
 profile.addMatch('10bit', /10.?bit/, 10).setQuality(15).require('video_codec');
 profile.addMatch('10bit', 'Hi10P', 25).setQuality(15).require('video_codec');
-profile.addMatch('8bit', /8.?bit/, 10).setQuality(15);
+profile.addMatch('8bit', /8.?bit/, 10).setQuality(15).positionAfter('title');
 profile.addMatch('Hi422P', 'Hi422P', 45).setQuality(25).require('video_codec');
 profile.addMatch('Hi422P', 'Hi444P', 45).setQuality(25).require('video_codec');
 

--- a/test/episodes-epinfer.yaml
+++ b/test/episodes-epinfer.yaml
@@ -540,3 +540,15 @@ Vikings.1x03.La.Pêche.Miraculeuse.FR.LD.HDTV.XviD-MiND.[tvu.org.ru].mp4:
   series: 'Vikings'
   release_group: 'MiND'
   title: 'La Pêche Miraculeuse'
+
+Dara.O.Briains.Go.8Bit.S01E01.WEB.h264-TASTETV.mkv:
+  subtype: 'episode'
+  container: 'Matroska'
+  extension: 'mkv'
+  filetype: 'video'
+  episode: 1
+  season: 1
+  format: 'WEB-DL'
+  video_codec: 'h264'
+  release_group: 'TASTETV'
+  series: 'Dara O Briains Go 8bit'


### PR DESCRIPTION
I ran into a parse issue on this:
```
Dara.O.Briains.Go.8Bit.S01E01.WEB.h264-TASTETV.mkv
```

Because of the _"8Bit"_ in the series name, it was mis-parsed (it matches the `video_profile` property) and the series name was undefined.